### PR TITLE
added permission yml and updated docker-compose file to use it

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,7 +37,9 @@ services:
       # For localhost, use Dockers internal 'host.docker.internal'.
       SPIFFWORKFLOW_BACKEND_OPEN_ID_SERVER_URL: "http://<YOUR_IP>:8010/openid"
 
-      SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME: "example.yml"
+      # SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_NAME: "example.yml"
+      SPIFFWORKFLOW_BACKEND_PERMISSIONS_FILE_ABSOLUTE_PATH: "/app/permissions/permissions.yml"
+
       SPIFFWORKFLOW_BACKEND_PORT: "${SPIFF_BACKEND_PORT:-8000}"
       SPIFFWORKFLOW_BACKEND_RUN_BACKGROUND_SCHEDULER_IN_CREATE_APP: "true"
       SPIFFWORKFLOW_BACKEND_UPGRADE_DB: "true"
@@ -47,6 +49,7 @@ services:
     volumes:
       - ./process_models:/app/process_models
       - spiffworkflow_backend_db:/app/db_volume
+      - ./permissions:/app/permissions
     healthcheck:
       test: "curl localhost:${SPIFF_BACKEND_PORT:-8000}/v1.0/status --fail"
       interval: 10s

--- a/permissions/permissions.yml
+++ b/permissions/permissions.yml
@@ -1,0 +1,40 @@
+groups:
+  admin:
+    users:
+      [
+        admin@example.com,
+      ]
+  approvers:
+    users:
+      [
+        test1@example.com
+      ]
+
+permissions:
+  # Admins have access to everything.
+  admin:
+    groups: [admin]
+    actions: [all]
+    uri: /*
+
+  # Everybody can participate in tasks assigned to them.
+  # BASIC, PG, PM, are documented at https://spiff-arena.readthedocs.io/en/latest/DevOps_installation_integration/permission_url.html
+  basic:
+    groups: [everybody]
+    actions: [all]
+    uri: BASIC
+
+  # Everyone can see everything (all groups, and processes are visible)
+  read-all-process-groups:
+    groups: [ everybody ]
+    actions: [ read ]
+    uri: PG:ALL
+  read-all-process-models:
+    groups: [ everybody ]
+    actions: [ read ]
+    uri: PM:ALL
+  run-all-process-models:
+    groups: [ everybody ]
+    actions: [ start ]
+    uri: PM:ALL
+


### PR DESCRIPTION
This adds a permissions yml that can be used in the app. It will set up basic permissions for an admin and a test user. More can be added to it.

The important thing is using the email address in the permission file. We use the email address as the username in the backend database to help ensure uniqueness across open id systems.